### PR TITLE
TRITON-2346 Fix assertion thrown when running full-cache-refresh

### DIFF
--- a/lib/booter.js
+++ b/lib/booter.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -126,9 +127,12 @@ function main() {
         break;
     case 'full-cache-refresh':
         var cacheSentinel = new mod_cache.CacheSentinel({
-            log: log, cnapi: cnapi, napi: napi,
-            adminUuid: config.adminUuid, cacheConfig: config.cache,
-            adminPoolCache: adminPoolCache});
+            log: log,
+            cnapi: cnapi,
+            napi: napi,
+            adminPoolCache: adminPoolCache,
+            config: config
+        });
         cacheSentinel.refreshCache();
         break;
     default:

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "booter",
   "description": "DHCP server for booting SDC compute nodes",
-  "version": "1.7.3",
-  "author": "Joyent (joyent.com)",
+  "version": "1.7.4",
+  "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {
     "assert-plus": "1.0.0",
@@ -15,7 +15,7 @@
     "node-uuid": "1.2.0",
     "pack": "file:build/pack-0.0.1.tgz",
     "restify": "4.3.0",
-    "sdc-bunyan-serializers": "git+https://github.com/joyent/sdc-bunyan-serializers.git#8fdb844",
+    "sdc-bunyan-serializers": "git+https://github.com/TritonDataCenter/sdc-bunyan-serializers.git#8fdb844",
     "sdc-clients": "13.0.3",
     "sprintf": "0.1.0",
     "vasync": "1.6.2",


### PR DESCRIPTION
`config` should be provided as a top-level property to the `CacheSentinel` constructor.
Also, since the `config` object is being provided, `adminUuid` and `cacheConfig` are also [no longer needed as top-level properties](https://github.com/TritonDataCenter/sdc-booter/blob/bece4967c1e06819d0a3bec1d9983b5a72b79586/lib/cache.js#L70).