### PR TITLE
TOOLS-2582 Slack channels need renaming or not specifying in Jenkinsfiles, post-EdgeCast-move.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2022 Joyent, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -64,7 +65,7 @@ pipeline {
 
     post {
         always {
-            joySlackNotifications(channel: 'jenkins')
+            joySlackNotifications()
         }
     }
 


### PR DESCRIPTION
Edited in github, creating PR from it.